### PR TITLE
fix delete cancelled event bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -711,7 +711,7 @@ function deleteCancelledEvents() {
 
     if (isPageUpdatedRecently(result)) {
       try {
-        let event_id = result.properties[EVENT_ID_NOTION].results;
+        let event_id = result.properties[EVENT_ID_NOTION].rich_text;
         let calendar_id = result.properties[CALENDAR_ID_NOTION].select.name;
 
         event_id = flattenRichText(event_id);


### PR DESCRIPTION
Fixes a bug in cancelled events related to trying to grab the event_id incorrectly introduced due to changes in the Notion API a while ago.